### PR TITLE
Disable VBE on non-x86, disable XAA, fix invalid VBIOS access

### DIFF
--- a/src/r128_driver.c
+++ b/src/r128_driver.c
@@ -94,7 +94,11 @@
 #include "xf86RandR12.h"
 #include "xf86cmap.h"
 #include "xf86xv.h"
+#if defined(__i386__) || defined(__x86_64__)
 #include "vbe.h"
+#else
+typedef void *xf86Int10InfoPtr;
+#endif
 
 				/* fbdevhw & vgahw */
 #ifdef WITH_VGAHW
@@ -419,11 +423,14 @@ static Bool R128GetBIOSParameters(ScrnInfoPtr pScrn, xf86Int10InfoPtr pInt10)
 	return FALSE;
     }
 
+#if defined(__x86_64__) || defined(__i386__)
     if (pInt10) {
 	info->BIOSAddr = pInt10->BIOSseg << 4;
 	(void)memcpy(info->VBIOS, xf86int10Addr(pInt10, info->BIOSAddr),
 		     R128_VBIOS_SIZE);
-    } else {
+    } else
+#endif
+    {
 #ifdef XSERVER_LIBPCIACCESS
 	if (pci_device_read_rom(info->PciInfo, info->VBIOS)) {
 	    xf86DrvMsg(pScrn->scrnIndex, X_WARNING,
@@ -1011,7 +1018,7 @@ static Bool R128PreInitConfig(ScrnInfoPtr pScrn)
 
 static Bool R128PreInitDDC(ScrnInfoPtr pScrn, xf86Int10InfoPtr pInt10)
 {
-#if !defined(__powerpc__) && !defined(__alpha__) && !defined(__sparc__)
+#if defined(__i386__) || defined(__x86_64__)
     R128InfoPtr   info = R128PTR(pScrn);
     vbeInfoPtr pVbe;
 #endif
@@ -1019,8 +1026,7 @@ static Bool R128PreInitDDC(ScrnInfoPtr pScrn, xf86Int10InfoPtr pInt10)
     if (!xf86LoadSubModule(pScrn, "ddc")) return FALSE;
     if (!xf86LoadSubModule(pScrn, "i2c")) return FALSE;
 
-#if defined(__powerpc__) || defined(__alpha__) || defined(__sparc__)
-    /* Int10 is broken on PPC and some Alphas */
+#if !defined(__i386__) && !defined(__x86_64__)
     return TRUE;
 #else
     if (xf86LoadSubModule(pScrn, "vbe")) {
@@ -1056,9 +1062,8 @@ static Bool R128PreInitCursor(ScrnInfoPtr pScrn)
 
 static Bool R128PreInitInt10(ScrnInfoPtr pScrn, xf86Int10InfoPtr *ppInt10)
 {
+#if defined(__i386__) || defined(__x86_64__)
     R128InfoPtr   info = R128PTR(pScrn);
-#if !defined(__powerpc__) && !defined(__alpha__)
-    /* int10 is broken on some Alphas and powerpc */
     if (xf86LoadSubModule(pScrn, "int10")) {
 	xf86DrvMsg(pScrn->scrnIndex,X_INFO,"initializing int10\n");
 	*ppInt10 = xf86InitInt10(info->pEnt->index);
@@ -1402,9 +1407,11 @@ static Bool R128LegacyMS(ScrnInfoPtr pScrn)
     ret = TRUE;
 freeInt10:
     /* Free int10 info */
+#if defined(__i386__) || defined(__x86_64__)
     if (pInt10) {
         xf86FreeInt10(pInt10);
     }
+#endif
 
 exit:
     return ret;

--- a/src/r128_output.c
+++ b/src/r128_output.c
@@ -483,6 +483,7 @@ R128GetConnectorInfoFromBIOS(ScrnInfoPtr pScrn, R128OutputType *otypes)
         } else {
             otypes[0] = OUTPUT_VGA;
         }
+        return;
     }
 
     bios_header = R128_BIOS16(0x48);


### PR DESCRIPTION
This should fix the driver on non-x86 platforms.

XAA disablement taken from:

https://code.foxkit.us/adelie/packages/blob/master/user/xf86-video-r128