### PR TITLE
Fix segfault from trying to access nonexistent VGA BIOS ROM on non-x86 platforms

### DIFF
--- a/src/r128_output.c
+++ b/src/r128_output.c
@@ -483,6 +483,7 @@ R128GetConnectorInfoFromBIOS(ScrnInfoPtr pScrn, R128OutputType *otypes)
         } else {
             otypes[0] = OUTPUT_VGA;
         }
+        return;
     }
 
     bios_header = R128_BIOS16(0x48);


### PR DESCRIPTION
On non-x86 platforms such as PowerPC Macs with r128 chipsets, the VGA BIOS ROM doesn't exist, and the driver segfaults when trying to access it. Fix this by only accessing the VGA BIOS on x86/x86_64.

Taken from https://github.com/void-linux/void-packages/blob/master/srcpkgs/xf86-video-r128/patches/fix-non-x86.patch
![uzcpd3xxwoif1](https://github.com/user-attachments/assets/824eb890-dbcd-4944-9597-71d8340059b1)
